### PR TITLE
Minor bugfixes for build-and-test

### DIFF
--- a/.github/workflows/Build-and-test.yml
+++ b/.github/workflows/Build-and-test.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "minor-bugfix-attempts-Teis" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "minor-bugfix-attempts-Teis" ]
 
 jobs:
   build:

--- a/.github/workflows/Build-and-test.yml
+++ b/.github/workflows/Build-and-test.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "minor-bugfix-attempts-Teis" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "minor-bugfix-attempts-Teis" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 /.idea
+/SimpleDB/bin
+/SimpleDB/obj
+/SimpleDB/obj

--- a/Chirp.CLI/Chirp.CLI.csproj
+++ b/Chirp.CLI/Chirp.CLI.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\simpleDB\SimpleDB.csproj" />
+    <ProjectReference Include="..\SimpleDB\SimpleDB.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Chirp.sln
+++ b/Chirp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chirp.CLI", "Chirp.CLI\Chirp.CLI.csproj", "{1A7AB262-1AB3-48AC-A73E-F97D02CED40A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleDB", "SimpleDB\SimpleDB.csproj", "{64366595-E2CF-4CA7-BA50-C5BFD9A741B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{1A7AB262-1AB3-48AC-A73E-F97D02CED40A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A7AB262-1AB3-48AC-A73E-F97D02CED40A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A7AB262-1AB3-48AC-A73E-F97D02CED40A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64366595-E2CF-4CA7-BA50-C5BFD9A741B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64366595-E2CF-4CA7-BA50-C5BFD9A741B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64366595-E2CF-4CA7-BA50-C5BFD9A741B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64366595-E2CF-4CA7-BA50-C5BFD9A741B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This is a quick bugfix branch made to deal with our test and build workflow not completing.

There are 3 changes, but one is just adding build artefact subfolders to gitignore.

The two "important" changes are:

1: fixing an lowercase letter that should be uppercase in chirp.cli.csproj

2: adding the SimpleDB project to chirp.sln

With these changes the workflow should build on main as well.